### PR TITLE
Add multiple consumers section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -755,6 +755,21 @@ is consumed by multiple consumers.
 Examples include the case where the result of a background blurring function should
 be both displayed in a self-view and encoded using a {{VideoEncoder}}.
 
+For cases where both consumers are consuming unprocessed frames, and synchronization
+is not desired, instantianting multiple {{MediaStreamTrackProcessor}} objects is a robust solution.
+
+For cases where both consumers intend to convert the result of a processing step into a
+{{MediaStreamTrack}}
+using a {{MediaStreamTrackGenerator}}, for example when feeding a processed stream
+to both a &lt;video&gt& tag and an {{RTCPeerConnection}}, attaching the resulting {{MediaStreamTrack}}
+to multiple sinks may be the most appropriate mechanism.
+
+For cases where the downstream processing takes frames, not streams, the frames can
+be cloned as needed and sent off to the downstream processing; "clone" is a cheap operation.
+
+When the stream is the output of some processing, and both branches need a Stream object
+to do further processing, one needs a function that produces two streams from one stream.
+
 However, the standard tee() operation is problematic
 in this context:
 
@@ -766,23 +781,10 @@ Therefore, the use of tee() with Streams containing media should only be done wh
 fully understanding the implications. Instead, custom elements for splitting streams
 more appropriate to the use case should be used.
 
-For cases where both consumers are consuming unprocessed frames, and synchronization
-is not desired, instantianting multiple {{MediaStreamTrackProcessor}} objects is a robust solution.
-
-For cases where both consumers intend to convert the result of a processing step into a
-{{MediaStreamTrack}}
-using a {{MediaStreamTrackGenerator}}, attaching the resulting {{MediaStreamTrack}} to
-multiple sinks may be the most appropriate mechanism.
-
-For cases where the downstream processing takes frames, not streams, the frames can
-be cloned as needed and sent off to the downstream processing; "clone" is a cheap operation.
-
-When the stream is the output of some processing, and both branches need a Stream object
-to do further processing, the correct way of splitting the stream depends on context:
-
 *   If both branches require the ability to dispose of the frames, clone() the frame
     and enqueue distinct copies in both queues. This corresponds to the function
-    ReadableStreamTee(stream, cloneForBranch2=true).
+    ReadableStreamTee(stream, cloneForBranch2=true). Then choose one of the
+    alternatives below.
 
 *   If one branch requires all frames, and the other branch tolerates dropped frames,
     enqueue buffers in the all-frames-required stream and use the backpressure signal
@@ -793,8 +795,7 @@ to do further processing, the correct way of splitting the stream depends on con
     to stop reading from the source. In this case, frames will be processed in
     lockstep if the buffer sizes are both 1.
 
-*   If one branch disposes of the frames, and the other branch does not, and it is
-    OK for the incoming stream to be stalled only when the underlying
+*   If it is OK for the incoming stream to be stalled only when the underlying
     buffer pool allocated to the process is exhausted, standard tee() may be used.
 
 # Security and Privacy considerations # {#security-considerations}

--- a/index.bs
+++ b/index.bs
@@ -754,7 +754,7 @@ in this context:
 
  * It defeats the backpressure mechanism that guards against excessive queueing
  * It creates multiple links to the same buffers, meaning that the question of which
-   consumer gets to destroy() the buffer is a difficult one to address
+consumer gets to destroy() the buffer is a difficult one to address
 
 Therefore, the use of tee() with Streams containing media should only be done when
 fully understanding the implications. Instead, custom elements for splitting streams
@@ -768,21 +768,21 @@ When both branches want to do further processing, the correct way of splitting t
 depends on context:
 
  * If both branches require the ability to dispose of the frames, clone() the frame
-   and enqueue distinct copies in both queues. This corresponds to the function
-   ReadableStreamTee(stream, cloneForBranch2=true).
+and enqueue distinct copies in both queues. This corresponds to the function
+ReadableStreamTee(stream, cloneForBranch2=true).
 
  * If one branch requires all frames, and the other branch tolerates dropped frames,
-   enqueue buffers in the all-frames-required stream and use the backpressure signal
-   from that stream to stop reading from the source. If backpressure signal from the
-   other stream indicates room, enqueue the same frame in that queue too.
+enqueue buffers in the all-frames-required stream and use the backpressure signal
+from that stream to stop reading from the source. If backpressure signal from the
+other stream indicates room, enqueue the same frame in that queue too.
 
  * If neither stream tolerates dropped frames, use the combined backpressure signal
-   to stop reading from the source. In this case, frames will be processed in
-   lockstep if the buffer sizes are both 1.
+to stop reading from the source. In this case, frames will be processed in
+lockstep if the buffer sizes are both 1.
 
  * If one branch disposes of the frames, and the other branch does not, and it is
-   OK for the incoming stream to be stalled only when the underlying
-   buffer pool allocated to the process is exhausted, standard tee() may be used.
+OK for the incoming stream to be stalled only when the underlying
+buffer pool allocated to the process is exhausted, standard tee() may be used.
 
 # Security and Privacy considerations # {#security-considerations}
 

--- a/index.bs
+++ b/index.bs
@@ -15,6 +15,7 @@ Markup Shorthands: css no, markdown yes
 </pre>
 <pre class=anchors>
 url: https://wicg.github.io/web-codecs/#videoframe; text: VideoFrame; type: interface; spec: WEBCODECS
+url: https://wicg.github.io/web-codecs/#videoencoder; text: VideoEncoder; type: interface; spec: WEBCODECS
 url: https://wicg.github.io/web-codecs/#audiodata; text: AudioData; type: interface; spec: WEBCODECS
 url: https://www.w3.org/TR/mediacapture-streams/#mediastreamtrack; text: MediaStreamTrack; type: interface; spec: MEDIACAPTURE-STREAMS
 url: https://www.w3.org/TR/mediacapture-streams/#dom-constrainulong; text: ConstrainULong; type: typedef; spec: MEDIACAPTURE-STREAMS
@@ -749,7 +750,12 @@ This section is informative.
 ## Use with multiple consumers
 
 There are use cases where the programmer may desire that a single stream of frames
-is consumed by multiple consumers. However, the standard tee() operation is problematic
+is consumed by multiple consumers.
+
+Examples include the case where the result of a background blurring function should
+be both displayed in a self-view and encoded using a {{VideoEncoder}}.
+
+However, the standard tee() operation is problematic
 in this context:
 
 *   It defeats the backpressure mechanism that guards against excessive queueing
@@ -760,12 +766,16 @@ Therefore, the use of tee() with Streams containing media should only be done wh
 fully understanding the implications. Instead, custom elements for splitting streams
 more appropriate to the use case should be used.
 
-For cases where both consumers intend to convert the result into a MediaStreamTrack
-using a MediaStreamTrackGenerator, attaching the resulting MediaStreamTrack to
+For cases where both consumers are consuming unprocessed frames, and synchronization
+is not desired, instantianting multiple {{MediaStreamTrackProcessor}} objects is a robust solution.
+
+For cases where both consumers intend to convert the result of a processing step into a
+{{MediaStreamTrack}}
+using a {{MediaStreamTrackGenerator}}, attaching the resulting {{MediaStreamTrack}} to
 multiple sinks may be the most appropriate mechanism.
 
-When both branches want to do further processing, the correct way of splitting the stream
-depends on context:
+When the stream is the output of some processing, and both branches want to do further processing,
+the correct way of splitting the stream depends on context:
 
 *   If both branches require the ability to dispose of the frames, clone() the frame
     and enqueue distinct copies in both queues. This corresponds to the function

--- a/index.bs
+++ b/index.bs
@@ -742,6 +742,48 @@ self.onmessage = async function(e) {
 }
 </pre>
 
+# Implementation advice # {#implementation-advice}
+
+This section is informative.
+
+## Use with multiple consumers ##
+
+There are use cases where the programmer may desire that a single stream of frames
+is consumed by multiple consumers. However, the standard tee() operation is problematic
+in this context:
+
+ * It defeats the backpressure mechanism that guards against excessive queueing
+ * It creates multiple links to the same buffers, meaning that the question of which
+   consumer gets to destroy() the buffer is a difficult one to address
+
+Therefore, the use of tee() with Streams containing media should only be done when
+fully understanding the implications. Instead, custom elements for splitting streams
+more appropriate to the use case should be used.
+
+For cases where both consumers intend to convert the result into a MediaStreamTrack
+using a MediaStreamTrackGenerator, attaching the resulting MediaStreamTrack to
+multiple sinks may be the most appropriate mechanism.
+
+When both branches want to do further processing, the correct way of splitting the stream
+depends on context:
+
+ * If both branches require the ability to dispose of the frames, clone() the frame
+   and enqueue distinct copies in both queues. This corresponds to the function
+   ReadableStreamTee(stream, cloneForBranch2=true).
+
+ * If one branch requires all frames, and the other branch tolerates dropped frames,
+   enqueue buffers in the all-frames-required stream and use the backpressure signal
+   from that stream to stop reading from the source. If backpressure signal from the
+   other stream indicates room, enqueue the same frame in that queue too.
+
+ * If neither stream tolerates dropped frames, use the combined backpressure signal
+   to stop reading from the source. In this case, frames will be processed in
+   lockstep if the buffer sizes are both 1.
+
+ * If one branch disposes of the frames, and the other branch does not, and it is
+   OK for the incoming stream to be stalled only when the underlying
+   buffer pool allocated to the process is exhausted, standard tee() may be used.
+
 # Security and Privacy considerations # {#security-considerations}
 
 This API defines a {{MediaStreamTrack}} source and a {{MediaStreamTrack}} sink.

--- a/index.bs
+++ b/index.bs
@@ -774,8 +774,11 @@ For cases where both consumers intend to convert the result of a processing step
 using a {{MediaStreamTrackGenerator}}, attaching the resulting {{MediaStreamTrack}} to
 multiple sinks may be the most appropriate mechanism.
 
-When the stream is the output of some processing, and both branches want to do further processing,
-the correct way of splitting the stream depends on context:
+For cases where the downstream processing takes frames, not streams, the frames can
+be cloned as needed and sent off to the downstream processing; "clone" is a cheap operation.
+
+When the stream is the output of some processing, and both branches need a Stream object
+to do further processing, the correct way of splitting the stream depends on context:
 
 *   If both branches require the ability to dispose of the frames, clone() the frame
     and enqueue distinct copies in both queues. This corresponds to the function

--- a/index.bs
+++ b/index.bs
@@ -746,7 +746,7 @@ self.onmessage = async function(e) {
 
 This section is informative.
 
-## Use with multiple consumers ##
+## Use with multiple consumers
 
 There are use cases where the programmer may desire that a single stream of frames
 is consumed by multiple consumers. However, the standard tee() operation is problematic

--- a/index.bs
+++ b/index.bs
@@ -752,9 +752,9 @@ There are use cases where the programmer may desire that a single stream of fram
 is consumed by multiple consumers. However, the standard tee() operation is problematic
 in this context:
 
- * It defeats the backpressure mechanism that guards against excessive queueing
- * It creates multiple links to the same buffers, meaning that the question of which
-consumer gets to destroy() the buffer is a difficult one to address
+*   It defeats the backpressure mechanism that guards against excessive queueing
+*   It creates multiple links to the same buffers, meaning that the question of which
+    consumer gets to destroy() the buffer is a difficult one to address
 
 Therefore, the use of tee() with Streams containing media should only be done when
 fully understanding the implications. Instead, custom elements for splitting streams
@@ -767,22 +767,22 @@ multiple sinks may be the most appropriate mechanism.
 When both branches want to do further processing, the correct way of splitting the stream
 depends on context:
 
- * If both branches require the ability to dispose of the frames, clone() the frame
-and enqueue distinct copies in both queues. This corresponds to the function
-ReadableStreamTee(stream, cloneForBranch2=true).
+*   If both branches require the ability to dispose of the frames, clone() the frame
+    and enqueue distinct copies in both queues. This corresponds to the function
+    ReadableStreamTee(stream, cloneForBranch2=true).
 
- * If one branch requires all frames, and the other branch tolerates dropped frames,
-enqueue buffers in the all-frames-required stream and use the backpressure signal
-from that stream to stop reading from the source. If backpressure signal from the
-other stream indicates room, enqueue the same frame in that queue too.
+*   If one branch requires all frames, and the other branch tolerates dropped frames,
+    enqueue buffers in the all-frames-required stream and use the backpressure signal
+    from that stream to stop reading from the source. If backpressure signal from the
+    other stream indicates room, enqueue the same frame in that queue too.
 
- * If neither stream tolerates dropped frames, use the combined backpressure signal
-to stop reading from the source. In this case, frames will be processed in
-lockstep if the buffer sizes are both 1.
+*   If neither stream tolerates dropped frames, use the combined backpressure signal
+    to stop reading from the source. In this case, frames will be processed in
+    lockstep if the buffer sizes are both 1.
 
- * If one branch disposes of the frames, and the other branch does not, and it is
-OK for the incoming stream to be stalled only when the underlying
-buffer pool allocated to the process is exhausted, standard tee() may be used.
+*   If one branch disposes of the frames, and the other branch does not, and it is
+    OK for the incoming stream to be stalled only when the underlying
+    buffer pool allocated to the process is exhausted, standard tee() may be used.
 
 # Security and Privacy considerations # {#security-considerations}
 


### PR DESCRIPTION
This explains why use of tee() is problematic for many cases, and suggests more appropriate mechanisms for some scenarios.

Fixes #58


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-transform/pull/57.html" title="Last updated on Aug 12, 2021, 11:08 AM UTC (9fef01f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-transform/57/c384907...9fef01f.html" title="Last updated on Aug 12, 2021, 11:08 AM UTC (9fef01f)">Diff</a>