### PR TITLE
Make MediaStreamTrackProcessor.readable readonly

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -114,7 +114,7 @@ does not give the UA enough flexibility to choose the buffering policy.
 [Exposed=DedicatedWorker]
 interface MediaStreamTrackProcessor {
     constructor(MediaStreamTrackProcessorInit init);
-    attribute ReadableStream readable;
+    readonly attribute ReadableStream readable;
 };
 
 dictionary MediaStreamTrackProcessorInit {


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-transform/pull/90.html" title="Last updated on Jan 12, 2024, 2:51 PM UTC (417e6f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-transform/90/efec34b...youennf:417e6f0.html" title="Last updated on Jan 12, 2024, 2:51 PM UTC (417e6f0)">Diff</a>