### PR TITLE
Update Detached slot to link to html spec.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14,7 +14,6 @@ Abstract: {{MediaStreamTrack}}s carrying raw data.
 Markup Shorthands: css no, markdown yes
 </pre>
 <pre class=anchors>
-url: https://w3c.github.io/webcodecs/#close-videoframe; text: Close VideoFrame; type: dfn; spec: WEBCODECS
 url: https://w3c.github.io/webcodecs/#videoframe; text: VideoFrame; type: interface; spec: WEBCODECS
 url: https://w3c.github.io/webcodecs/#videoencoder; text: VideoEncoder; type: interface; spec: WEBCODECS
 url: https://streams.spec.whatwg.org/#readablestream-controller; text: [[controller]]; for: ReadableStream; type: dfn; spec: STREAMS
@@ -301,7 +300,7 @@ is accessed for the first time, it MUST be initialized with the following steps:
 
 The <dfn>writeFrame</dfn> algorithm is given a |generator| and a |frame| as input. It is defined by running the following steps:
 1. If |frame| is not a {{VideoFrame}} object, return [=a promise rejected with=] a {{TypeError}}.
-1. If the value of |frame|’s [[Detached]] internal slot is true, return [=a promise rejected with=] a {{TypeError}}.
+1. If the value of |frame|’s {{platform object/[[Detached]]}} internal slot is true, return [=a promise rejected with=] a {{TypeError}}.
 1. If |generator|.`[[isMuted]]` is false, send the media data backing |frame| to all live tracks sourced from |generator|.
 1. Run the [=Close VideoFrame=] algorithm with |frame|.
 1. Return [=a promise resolved with=] undefined.


### PR DESCRIPTION
Remove the close videoframe specific link now that it is exported in WebCodecs spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-transform/pull/107.html" title="Last updated on Feb 8, 2024, 5:04 PM UTC (8655a06)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-transform/107/607f1d9...youennf:8655a06.html" title="Last updated on Feb 8, 2024, 5:04 PM UTC (8655a06)">Diff</a>